### PR TITLE
Normalize content to match RFC-821 rule

### DIFF
--- a/src/mailer/Mail.php
+++ b/src/mailer/Mail.php
@@ -578,7 +578,7 @@ class Mail
 
     public function html($html)
     {
-        $this->html = $html;
+        $this->html = $this->normalize($html);
 
         return $this;
     }
@@ -593,7 +593,7 @@ class Mail
 
     public function text($text)
     {
-        $this->text = wordwrap(strip_tags($text), $this->wordwrap);
+        $this->text = $this->normalize(wordwrap(strip_tags($text), $this->wordwrap));
 
         return $this;
     }
@@ -1135,6 +1135,34 @@ class Mail
         {
             return '<' . $recipient['email'] . '>';
         }
+    }
+    
+    /**
+     * Normalize content to match RFC-821 max 1000 characters line length including the CRLF
+     *
+     * @access  private
+     * @param   string   $lines  Lines content
+     * @return  string
+     */
+
+    private function normalize($lines)
+    {
+        // Replace line breaks
+
+        $lines = str_replace("\r", "\n", $lines);
+
+        // Split lines
+
+        $content = '';
+        foreach(explode("\n", $lines) as $line)
+        {
+            foreach(str_split($line, 998) as $result)
+            {
+                $content .= $result . $this->newline;
+            }
+        }
+
+        return $content;
     }
 
     /**


### PR DESCRIPTION
Strip content to match max 1000 characters line length including the CRLF according to RFC-821 rule.

Some SMTP servers doesn't strip lines automatically and returns the following error (SMTP error from remote mail server after end of data: 500 5.5.0 Line too long)
